### PR TITLE
Make hud UI 2

### DIFF
--- a/Content/ProjectEscape/Maps/GameStartLevel.umap
+++ b/Content/ProjectEscape/Maps/GameStartLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2afe42aa140aa106f9b894c8ec56fdb72f414c284ac4970b4848ad0f2f626e5c
+oid sha256:0f43a5978797b9769375cc6c0fce6ecb1a80997792ac58649c0c0ce1ab69ca25
 size 9164

--- a/Content/ProjectEscape/UI/Menu/WBP_MainMenu.uasset
+++ b/Content/ProjectEscape/UI/Menu/WBP_MainMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8e80ee4b391b4de6e9efa92061fca206ad8b6039198d66afda74e3c858af6995
-size 160350
+oid sha256:aeac32bfcd5720ceadbff00073dc533dd24c97c9885cd5d0428db7d26c2ad82b
+size 159936

--- a/Content/ProjectEscape/UI/Menu/WBP_PauseMenu.uasset
+++ b/Content/ProjectEscape/UI/Menu/WBP_PauseMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6f26be37e7126337a792d258e57ca5c403b86752ce6ffdc1bfd331b33e236a1
-size 119373
+oid sha256:e1bb52184ce2b5a5832497392bbcdc55c6b7b0a6d4fc6d25b30db48f08ad2364
+size 159563


### PR DESCRIPTION
기능추가


### 변경 사항 요약
<!-- 이 PR에서 어떤 변경이 있었는지 요약해주세요 -->
- 메인메뉴 게임종료 / 퍼즈메뉴 게임 종료 시 확인 UI 추가

---

### 테스트 방법
<!-- 구현한 내용을 어떻게 확인할 수 있는지, 어떻게 테스트할 수 있는지 설명하세요 -->
1. 게임 시작후 exit 버튼 클릭 후 확인 UI 나타나고 뒷배경 블러처리
2. pause 메뉴도 똑같지만 메인메뉴 레벨로 이동

---

### 스크린샷 (선택사항)
<!-- 변경 사항을 보여줄 스크린샷을 첨부해주세요 -->
<img width="835" height="407" alt="image" src="https://github.com/user-attachments/assets/f9ba4ce4-cbc9-4b9c-b838-6db7c24d1d86" />

---

### 셀프 체크리스트
- [ ] Code Convension을 지켰는가?
- [ ] 불필요한 코드와 주석을 제거했는가?
- [x] 구현한 내용에 문제가 없는가?
<!-- [x] 체크박스는 [] 안에 x를 넣어서 표시할 수 있습니다. -->

---

### 기타 사항
<!-- 리뷰어에게 전달하고 싶은 메시지나 참고할 만한 내용을 적어주세요 -->
 예술적 재능이 없어서 꾸미는게 너무 어렵네요
---

> 🙏 리뷰 감사합니다!