### PR TITLE
4, 5번 아이템을 'G' 키로 드랍했을 때 아이템이 복제되는 문제 수정

### DIFF
--- a/Source/ProjectEscape/Private/Characters/Hero/PEHero.cpp
+++ b/Source/ProjectEscape/Private/Characters/Hero/PEHero.cpp
@@ -222,10 +222,36 @@ void APEHero::HandEquipment(EPEEquipmentType EquipmentType)
 
 void APEHero::DropHandEquipmentToWorld()
 {
-	if (UseableItemManagerComponent)
+	if (UseableItemManagerComponent && InventoryManagerComponent)
 	{
-		UseableItemManagerComponent->DropHandEquipmentToWorld();
+		if (UPEUseableComponent* CurrentItem = UseableItemManagerComponent->GetCurrentItem())
+		{
+			if (UPEStorableItemComponent* StorableItem = InventoryManagerComponent->GetItemByTag(CurrentItem->GetGameplayTag()))
+			{
+				if (StorableItem->GetItemCount() <= 1)
+				{
+					QuickSlotManagerComponent->RemoveQuickSlotItem(CurrentItem->GetEquipmentType());
+					UseableItemManagerComponent->ReleaseHandItem();
+					CurrentItem->Release();
+				
+					FPEEquipmentInfo EquipmentInfo;
+					EquipmentInfo.EquipmentName = FName(" ");
+					EquipmentInfo.AmmoCount = TEXT(" ");
+					EquipmentInfo.EquipmentDescription = TEXT(" ");
+					EquipmentInfo.EquipmentIcon = nullptr;
+				
+					BroadCastEquipmentChanged(EquipmentInfo);
+				}
+				InventoryManagerComponent->DropItemFromInventoryByTag(1, CurrentItem->GetGameplayTag());
+			}
+			else
+			{
+				UseableItemManagerComponent->DropHandEquipmentToWorld();
+			}
+		}
+		
 	}
+	
 }
 
 void APEHero::HandleDropEquipmentToWorld(FGameplayTag EquipmentTag)

--- a/Source/ProjectEscape/Private/Items/Components/PEUseableComponent.cpp
+++ b/Source/ProjectEscape/Private/Items/Components/PEUseableComponent.cpp
@@ -3,6 +3,7 @@
 
 #include "Items/Components/PEUseableComponent.h"
 
+#include "GameplayTagContainer.h"
 #include "Core/PELogChannels.h"
 #include "Items/Interface/PEQuickSlotItem.h"
 #include "Items/Interface/PEUseable.h"
@@ -131,4 +132,13 @@ EPEEquipmentType UPEUseableComponent::GetEquipmentType() const
 	}
 	UE_LOG(LogPE, Warning, TEXT("UPEUseableComponent::GetEquipmentType: Owner %s does not implement IPEQuickSlotItem interface!"), *GetOwner()->GetName());
 	return EPEEquipmentType::None; // 기본값 반환
+}
+
+FGameplayTag UPEUseableComponent::GetGameplayTag() const
+{
+	if (IPEUseable* UseableInterface = Cast<IPEUseable>(GetOwner()))
+	{
+		return UseableInterface->GetItemTag();
+	}
+	return FGameplayTag::EmptyTag; // 기본값 반환
 }

--- a/Source/ProjectEscape/Private/Items/PEItemUseable.cpp
+++ b/Source/ProjectEscape/Private/Items/PEItemUseable.cpp
@@ -113,6 +113,11 @@ UPEUseableComponent* APEItemUseable::GetUseableComponent() const
 	return UseableComponent;	
 }
 
+FGameplayTag APEItemUseable::GetItemTag() const
+{
+	return ItemStats.ItemTag;
+}
+
 FPEEquipmentInfo APEItemUseable::CreateCurrentEquipmentInfo() const
 {
 	FPEEquipmentInfo EquipmentInfo;

--- a/Source/ProjectEscape/Private/Items/Weapons/PEWeaponBase.cpp
+++ b/Source/ProjectEscape/Private/Items/Weapons/PEWeaponBase.cpp
@@ -440,6 +440,11 @@ UPEUseableComponent* APEWeaponBase::GetUseableComponent() const
 	return HoldableComponent;
 }
 
+FGameplayTag APEWeaponBase::GetItemTag() const
+{
+	return FGameplayTag::EmptyTag;
+}
+
 AActor* APEWeaponBase::GetItemOwner() const
 {
 	return WeaponOwnerActor;

--- a/Source/ProjectEscape/Public/Items/Components/PEUseableComponent.h
+++ b/Source/ProjectEscape/Public/Items/Components/PEUseableComponent.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameplayTagContainer.h"
 #include "Components/ActorComponent.h"
 #include "PEUseableComponent.generated.h"
 
@@ -55,4 +56,5 @@ public:
 	bool IsHolding() const;
 
 	EPEEquipmentType GetEquipmentType() const;
+	FGameplayTag GetGameplayTag() const;
 };

--- a/Source/ProjectEscape/Public/Items/Interface/PEUseable.h
+++ b/Source/ProjectEscape/Public/Items/Interface/PEUseable.h
@@ -6,6 +6,7 @@
 #include "UObject/Interface.h"
 #include "PEUseable.generated.h"
 
+struct FGameplayTag;
 class UPEUseableComponent;
 // This class does not need to be modified.
 UINTERFACE()
@@ -28,5 +29,6 @@ public:
 	virtual void DoTertiaryAction(AActor* Holder) = 0;
 	virtual void OnHand(AActor* NewOwner) = 0;
 	virtual void OnRelease() = 0;
-	virtual UPEUseableComponent* GetUseableComponent() const = 0; 
+	virtual UPEUseableComponent* GetUseableComponent() const = 0;
+	virtual FGameplayTag GetItemTag() const = 0;
 };

--- a/Source/ProjectEscape/Public/Items/PEItemUseable.h
+++ b/Source/ProjectEscape/Public/Items/PEItemUseable.h
@@ -62,7 +62,8 @@ public:
 	virtual void DoTertiaryAction(AActor* Holder) override;
 	virtual void OnHand(AActor* NewOwner) override;
 	virtual void OnRelease() override;
-	virtual UPEUseableComponent* GetUseableComponent() const override; 
+	virtual UPEUseableComponent* GetUseableComponent() const override;
+	virtual FGameplayTag GetItemTag() const override;
 
 	/* UI 반영 델리게이트 헬퍼 함수 관련 섹션 */
 protected:

--- a/Source/ProjectEscape/Public/Items/Weapons/PEWeaponBase.h
+++ b/Source/ProjectEscape/Public/Items/Weapons/PEWeaponBase.h
@@ -123,6 +123,7 @@ public:
 	virtual void OnHand(AActor* NewOwner) override;
 	virtual void OnRelease() override;
 	virtual UPEUseableComponent* GetUseableComponent() const override;
+	virtual FGameplayTag GetItemTag() const override;
 
 	/* Combat(Attack) 관련 섹션 */
 protected:


### PR DESCRIPTION
### 변경 사항 요약
<!-- 이 PR에서 어떤 변경이 있었는지 요약해주세요 -->
- 4, 5번 아이템을 'G' 키로 드랍했을 때 아이템이 복제되는 문제 수정
- 이제 G키로 아이템을 한개 씩 떨굴 수 있습니다.

---

### 테스트 방법
<!-- 구현한 내용을 어떻게 확인할 수 있는지, 어떻게 테스트할 수 있는지 설명하세요 -->
1. 회복아이템, 수류탄 같은 아이템들 퀵슬롯에 장착
2. 'G' 키로 아이템 드랍해보기
---

### 스크린샷 (선택사항)
<!-- 변경 사항을 보여줄 스크린샷을 첨부해주세요 -->

---

### 셀프 체크리스트
- [x] Code Convension을 지켰는가?
- [x] 불필요한 코드와 주석을 제거했는가?
- [x] 구현한 내용에 문제가 없는가?
<!-- [x] 체크박스는 [] 안에 x를 넣어서 표시할 수 있습니다. -->

---

### 기타 사항
<!-- 리뷰어에게 전달하고 싶은 메시지나 참고할 만한 내용을 적어주세요 -->

---

> 🙏 리뷰 감사합니다!